### PR TITLE
chore: remove wdm dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby "3.4.5"
+
 gem "github-pages", "~> 232", group: :jekyll_plugins
 gem "minima", "~> 2.5"
 group :jekyll_plugins do
@@ -12,6 +14,3 @@ platforms :mingw, :x64_mingw, :mswin, :jruby do
   gem "tzinfo", "~> 2.0"
   gem "tzinfo-data"
 end
-
-# Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,8 +275,8 @@ GEM
     webrick (1.9.1)
 
 PLATFORMS
-  arm64-darwin-21
-  x86_64-linux
+  arm64-darwin
+  x86_64-linux-gnu
 
 DEPENDENCIES
   github-pages (~> 232)
@@ -284,7 +284,9 @@ DEPENDENCIES
   minima (~> 2.5)
   tzinfo (~> 2.0)
   tzinfo-data
-  wdm (~> 0.1.1)
+
+RUBY VERSION
+   ruby 3.4.5p51
 
 BUNDLED WITH
-   2.2.31
+   2.6.9


### PR DESCRIPTION
Remove wdm dependency as it's unnecessary (dev on macOS / deploy in ubuntu)