### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,18 +3,23 @@ name: Build Zola Site
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -29,6 +34,6 @@ jobs:
         run: pnpm build
 
       - name: Build Zola site
-        uses: getzola/github-pages@435a833fd3f1edcb28d70576c89e30a6365cd8f7
+        uses: getzola/github-pages@435a833fd3f1edcb28d70576c89e30a6365cd8f7 # v1
         with:
           zola_version: 'v0.22.1'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,10 +6,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -18,6 +15,8 @@ concurrency:
 jobs:
   build:
     name: Build
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yml
 
   deploy:
@@ -27,6 +26,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-24.04
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,84 @@
+name: Lint GitHub Actions
+
+on:
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  changes:
+    name: Detect workflow changes
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    outputs:
+      github: ${{ steps.filter.outputs.github }}
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            github:
+              - '.github/**'
+
+  lint:
+    name: Lint
+    needs: changes
+    if: needs.changes.outputs.github == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          # renovate: datasource=github-releases depName=zizmorcore/zizmor
+          version: "1.26.1"
+          advanced-security: false
+          annotations: true
+
+      - name: Run actionlint
+        env:
+          # renovate: datasource=github-releases depName=rhysd/actionlint
+          ACTIONLINT_VERSION: 1.7.12
+        run: |
+          curl -fsSL -o actionlint-matcher.json "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/.github/actionlint-matcher.json"
+          echo "::add-matcher::actionlint-matcher.json"
+          bash <(curl -fsSL "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash") "${ACTIONLINT_VERSION}"
+          ./actionlint -color
+        shell: bash
+
+      - name: Verify actions are pinned
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          fix: "false"
+
+  gate:
+    name: Lint gate
+    if: always()
+    needs: [changes, lint]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check lint outcome
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+        run: |
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "Change detection did not succeed (result: $CHANGES_RESULT)"
+            exit 1
+          fi
+          if [ "$LINT_RESULT" = "failure" ] || [ "$LINT_RESULT" = "cancelled" ]; then
+            echo "Lint failed (result: $LINT_RESULT)"
+            exit 1
+          fi
+          echo "OK (changes: $CHANGES_RESULT, lint: $LINT_RESULT)"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,19 +3,26 @@ name: Pull Request
 on:
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -31,4 +38,6 @@ jobs:
 
   build:
     name: Build
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yml


### PR DESCRIPTION
## Overview

Security-hardening pass across all workflow files, closing the standard set of weaknesses flagged by `zizmor` / `actionlint`, plus a new lint workflow that keeps them enforced.

## Changes

- **Least-privilege permissions** — top-level `permissions: {}` on every workflow. The reusable `build.yml` runs with only `contents: read`; on the deploy the sensitive `id-token: write` is scoped to the `deploy` job only, and callers pass `contents: read` to the reusable build.
- **Concurrency guards** — the PR workflow cancels superseded runs except on `main`; the Pages deploy keeps its serialized `pages` group with `cancel-in-progress: false` (deploys are never cancelled).
- **No persisted checkout credentials** — `persist-credentials: false` on every `actions/checkout`.
- **Pin the last unpinned action** — `getzola/github-pages` was referenced by a bare tag; it is now pinned to a full commit SHA with a `# v1` comment. Existing abbreviated pin tags were normalized to exact versions.
- **New `lint-actions.yml`** — runs `zizmor` + `actionlint` + `pinact` on `.github/**` changes, behind a fail-closed `gate` job that acts as a stable required status check.

## Testing

- Lint/PR paths are exercised by this PR's `Pull Request` and `Lint GitHub Actions` runs. Verified locally clean with `actionlint`, `zizmor --min-severity low --min-confidence medium`, and `pinact run --check --verify`.
- **Pages deploy** (not exercised by this PR): after merge, trigger `Deploy to GitHub Pages` (push to `main` or `workflow_dispatch`) and confirm the `github-pages` environment deploy succeeds and the site loads — the reusable build must upload the Pages artifact under `contents: read`, and the `deploy` job must publish it with the scoped `pages: write` + `id-token: write`.
