### PR TITLE
chore: move Linkita submodule to GitHub tera1 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "themes/linkita"]
 	path = themes/linkita
-	url = https://codeberg.org/salif/linkita.git
-	branch = v4
+	url = https://github.com/salif/linkita.git
+	branch = tera1

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ installs the latest release, so download a 0.22.x build from the
 
 ### Install the theme
 
-The [Linkita](https://codeberg.org/salif/linkita) theme is installed as a git submodule. After cloning, initialize it:
+The [Linkita](https://github.com/salif/linkita) theme is installed as a git submodule. After cloning, initialize it:
 
 ```bash
 git submodule update --init --recursive


### PR DESCRIPTION
The Linkita theme has moved from Codeberg to GitHub. Its author plans to delete the Codeberg
repository within a few months, which would break the site build the day it happens, since
the theme is consumed as a git submodule pointing at that host.

This repoints the submodule at the GitHub repository and tracks the `tera1` branch, which is
where the author will continue maintaining the Tera 1 line of the theme (Tera 2 / Zola 0.23
support will land separately on `main`).

The exact theme revision in use is unchanged — that commit exists in both repositories, so
this is purely a change of source host. The rendered site is byte-for-byte identical.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>